### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/share.yml
+++ b/.github/workflows/share.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
         
       - name: Update secrets.
-        uses: google/secrets-sync-action@v1.4.1
+        uses: jpoehnelt/secrets-sync-action@v1.4.1
         with:
           SECRETS: |
             ^AWS*


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.